### PR TITLE
Add qvarset field to compiled library in checker/values.ml

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -481,7 +481,7 @@ let v_vodigest = Sum ("module_impl",0, [| [|String|]; [|String;String|] |])
 let v_deps = Array (v_tuple "dep" [|v_dp;v_vodigest|])
 let v_flags = v_tuple "flags" [|v_bool|] (* Allow Rewrite Rules *)
 let v_compiled_lib =
-  v_tuple "compiled" [|v_dp;v_module;v_context_set;v_deps; v_flags|]
+  v_tuple "compiled" [|v_dp;v_module;v_context_set;v_set v_qvar;v_deps; v_flags|]
 
 (** STM objects *)
 


### PR DESCRIPTION
Fixes the issues with coqchk in the test-suite.